### PR TITLE
add approvers to reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,11 @@
 # Reviewers can /lgtm /approve but not sufficient for auto-merge without an
 # approver
 reviewers:
+- cstoku
 - makocchi-git
 - MasayaAoyama
+- nasa9084
+- tnir
 
 # Approvers have all the ability of reviewers but their /approve makes
 # auto-merge happen if a /lgtm exists, or vice versa, or they can do both


### PR DESCRIPTION
currently, there’re only 2 reviewers, so the bot assign them always. I think their load is slightly large.