### PR TITLE
add Japanese configuration in Hugo configuration

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -109,5 +109,9 @@ description = "Production-Grade Container Orchestration"
 languageName ="Chinese"
 weight = 2
 contentDir = "content/cn"
-
-
+[languages.ja]
+title = "Kubernetes"
+description = "Production-Grade Container Orchestration"
+languageName ="Japanese"
+weight = 3
+contentDir = "content/ja"


### PR DESCRIPTION
To start language.jp in hugo, this PR replaces #24, with keeping the original concept by @zembutsu and author information.

Co-authored-by: Takuya Noguchi <takninnovationresearch@gmail.com>
